### PR TITLE
Added missing "DigestValue" to dictionary

### DIFF
--- a/burp_wcf_plugin/src/NBFS.cs
+++ b/burp_wcf_plugin/src/NBFS.cs
@@ -209,6 +209,7 @@ public static class WcfDictionaryBuilder
         dict.Add("Transforms");
         dict.Add("Transform");
         dict.Add("DigestMethod");
+        dict.Add("DigestValue");
         dict.Add("Address");
         dict.Add("ReplyTo");
         dict.Add("SequenceAcknowledgement");


### PR DESCRIPTION
I added the missing "DigestValue" to dictionary between "DigestMethod" and "Address".
ref: https://msdn.microsoft.com/en-us/library/cc219187.aspx